### PR TITLE
Fix: resolve symbol namespacing. Ticket #8068

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -59,7 +59,7 @@ int logstamp = 0;         /* Timestamp (and pid stamp) messages */
  * *(uint16_t*)(cp), but will not cause segfaults on platforms that forbid
  * unaligned memory access.
  */
-uint16_t
+ATTR_HIDDEN uint16_t
 get_uint16(const char *cp)
 {
     uint16_t v;
@@ -71,7 +71,7 @@ get_uint16(const char *cp)
  * *(uint32_t*)(cp), but will not cause segfaults on platforms that forbid
  * unaligned memory access.
  */
-uint32_t
+ATTR_HIDDEN uint32_t
 get_uint32(const char *cp)
 {
     uint32_t v;
@@ -82,7 +82,7 @@ get_uint32(const char *cp)
  * Set a 16-bit value beginning at <b>cp</b> to <b>v</b>. Equivalent to
  * *(uint16_t)(cp) = v, but will not cause segfaults on platforms that forbid
  * unaligned memory access. */
-void
+ATTR_HIDDEN void
 set_uint16(char *cp, uint16_t v)
 {
     memcpy(cp,&v,2);
@@ -91,12 +91,13 @@ set_uint16(char *cp, uint16_t v)
  * Set a 32-bit value beginning at <b>cp</b> to <b>v</b>. Equivalent to
  * *(uint32_t)(cp) = v, but will not cause segfaults on platforms that forbid
  * unaligned memory access. */
-void
+ATTR_HIDDEN void
 set_uint32(char *cp, uint32_t v)
 {
     memcpy(cp,&v,4);
 }
 
+ATTR_HIDDEN
 unsigned int resolve_ip(char *host, int showmsg, int allownames) {
     struct hostent *new;
     unsigned int    hostaddr;
@@ -136,6 +137,7 @@ unsigned int resolve_ip(char *host, int showmsg, int allownames) {
 /*             be logged instead of to standard error           */
 /*  timestamp - This indicates that messages should be prefixed */
 /*              with timestamps (and the process id)            */
+ATTR_HIDDEN
 void set_log_options(int level, char *filename, int timestamp) {
 
    loglevel = level;
@@ -152,7 +154,7 @@ void set_log_options(int level, char *filename, int timestamp) {
 
 /* Count the bits in a netmask.  This is a little bit buggy; it assumes 
    all the zeroes are on the right... */
-
+ATTR_HIDDEN
 int count_netmask_bits(uint32_t mask)
 {
     int i;
@@ -171,6 +173,7 @@ int count_netmask_bits(uint32_t mask)
     return nbits;
 }
 
+ATTR_HIDDEN
 void show_msg(int level, const char *fmt, ...) {
     va_list ap;
     int saveerr;

--- a/src/common.h
+++ b/src/common.h
@@ -24,6 +24,7 @@
 #include <sys/types.h>
 
 #if defined(__GNUC__) && __GNUC__ >= 3
+#define ATTR_HIDDEN __attribute__((visibility("hidden")))
 #define ATTR_NORETURN __attribute__((noreturn))
 #define ATTR_PURE __attribute__((pure))
 #define ATTR_CONST __attribute__((const))

--- a/src/dead_pool.h
+++ b/src/dead_pool.h
@@ -54,7 +54,6 @@ dead_pool *init_pool(unsigned int deadpool_size, struct in_addr deadrange_base,
     struct in_addr deadrange_mask, char *sockshost, uint16_t socksport);
 int is_dead_address(dead_pool *pool, uint32_t addr);
 char *get_pool_entry(dead_pool *pool, struct in_addr *addr);
-int search_pool_for_name(dead_pool *pool, const char *name);
 struct hostent *our_gethostbyname(dead_pool *pool, const char *name);
 struct hostent *our_gethostbyaddr(dead_pool *pool, const void *addr,
                                   socklen_t len, int type);

--- a/src/parser.c
+++ b/src/parser.c
@@ -57,7 +57,9 @@ static int handle_tordns_cache_size(struct parsedfile *, char *);
 static int handle_defuser(struct parsedfile *, int, char *);
 static int handle_defpass(struct parsedfile *, int, char *);
 static int make_netent(char *value, struct netent **ent);
+static char *strsplit(char *separator, char **text, const char *search);
 
+ATTR_HIDDEN
 int read_config (char *filename, struct parsedfile *config) {
     FILE *conf;
     char line[MAXLINE];
@@ -756,6 +758,7 @@ int make_netent(char *value, struct netent **ent) {
     return(0);
 }
 
+ATTR_HIDDEN
 int is_local(struct parsedfile *config, struct in_addr *testip) {
     struct netent *ent;
     char buf[16];
@@ -799,6 +802,7 @@ int is_local(struct parsedfile *config, struct in_addr *testip) {
 }
 
 /* Find the appropriate server to reach an ip */
+ATTR_HIDDEN
 int pick_server(struct parsedfile *config, struct serverent **ent, 
                 struct in_addr *ip, unsigned int port) {
     struct netent *net;
@@ -843,7 +847,7 @@ int pick_server(struct parsedfile *config, struct serverent **ent,
 /* the start pointer is set to be NULL. The difference between      */
 /* standard strsep and this function is that this one will          */
 /* set *separator to the character separator found if it isn't null */
-char *strsplit(char *separator, char **text, const char *search) {
+static char *strsplit(char *separator, char **text, const char *search) {
    unsigned int len;
    char *ret;
 

--- a/src/parser.h
+++ b/src/parser.h
@@ -64,6 +64,5 @@ struct parsedfile {
 int read_config(char *, struct parsedfile *);
 int is_local(struct parsedfile *, struct in_addr *);
 int pick_server(struct parsedfile *, struct serverent **, struct in_addr *, unsigned int port);
-char *strsplit(char *separator, char **text, const char *search);
 
 #endif

--- a/src/socks.c
+++ b/src/socks.c
@@ -86,6 +86,7 @@ static int send_socksv4a_request(struct connreq *conn, const char *onion_host);
 dead_pool *pool = NULL;
 struct connreq *requests = NULL;
 
+ATTR_HIDDEN
 struct connreq *new_socks_request(int sockid, struct sockaddr_in *connaddr,
                                          struct sockaddr_in *serveraddr,
                                          struct serverent *path)
@@ -111,6 +112,7 @@ struct connreq *new_socks_request(int sockid, struct sockaddr_in *connaddr,
     return(newconn);
 }
 
+ATTR_HIDDEN
 void kill_socks_request(struct connreq *conn)
 {
     struct connreq *connnode;
@@ -129,6 +131,7 @@ void kill_socks_request(struct connreq *conn)
     free(conn);
 }
 
+ATTR_HIDDEN
 struct connreq *find_socks_request(int sockid, int includefinished)
 {
     struct connreq *connnode;
@@ -146,6 +149,7 @@ struct connreq *find_socks_request(int sockid, int includefinished)
     return(NULL);
 }
 
+ATTR_HIDDEN
 int handle_request(struct connreq *conn)
 {
     int rc = 0;


### PR DESCRIPTION
The hidden GCC attribute is better suited here instead of prefixing each
symbol with torsocks_\* in order to avoid polluting the library namespace
for no benefits.

Four symbols are made static since they were not used outside of their C
file. This automatically fix the exported symbol for these calls.

Fixes #8068

Signed-off-by: David Goulet dgoulet@ev0ke.net
