### PR TITLE
Bug3711 - Provide optimistic data by default

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -735,8 +735,9 @@ linux*)
       AC_TRY_COMPILE([
         #define _GNU_SOURCE
         #include <sys/socket.h>
-        int sendmmsg($testproto);
-      ],,[PROTO="$testproto";],)
+	#include <stdlib.h>
+      ],[sendmmsg(0, NULL, 0, 0)
+      ],[PROTO="$testproto";],)
     fi
   done
   if test "${PROTO}" = ""; then
@@ -762,8 +763,10 @@ linux*)
       AC_TRY_COMPILE([
         #define _GNU_SOURCE
         #include <sys/socket.h>
+        #include <stdlib.h>
         int recvmmsg($testproto);
-      ],,[PROTO="$testproto";],)
+      ],[recvmmsg(0, NULL, 0, 0, 0)
+      ],[PROTO="$testproto";],)
     fi
   done
   if test "${PROTO}" = ""; then

--- a/configure.in
+++ b/configure.in
@@ -647,7 +647,8 @@ TESTPROTO="${TESTPROTO}fd_set * writefds, "
 TESTPROTO="${TESTPROTO}fd_set * exceptfds, "
 TESTPROTO="${TESTPROTO}const struct timespec * timeout, "
 TESTPROTO="${TESTPROTO}const sigset_t * sigmask"
-for testproto in "${TESTPROTO}"
+TESTPROTO0=''
+for testproto in "${TESTPROTO}" "${TESTPROTO0}"
 do
   if test "${PROTO}" = ""; then
     AC_TRY_COMPILE([
@@ -700,7 +701,8 @@ linux*)
   AC_MSG_CHECKING(for correct sendmmsg prototype)
   PROTO=
   NAMES='s, msgvec, vlen, flags'
-  for testproto in 'int s, struct mmsghdr *msgvec, unsigned int vlen, int flags'
+  for testproto in 'int s, struct mmsghdr *msgvec, unsigned int vlen, int flags' \
+                   ''
   do
     if test "${PROTO}" = ""; then
       AC_TRY_COMPILE([
@@ -726,7 +728,8 @@ linux*)
   NAMES='s, msgvec, vlen, flags, timeout'
   TESTPROTO='int s, struct mmsghdr *msgvec, unsigned int vlen, int flags, '
   TESTPROTO="${TESTPROTO}const struct timespec *timeout"
-  for testproto in "${TESTPROTO}"
+  TESTPROTO0=''
+  for testproto in "${TESTPROTO}" "${TESTPROTO0}"
   do
     if test "${PROTO}" = ""; then
       AC_TRY_COMPILE([

--- a/configure.in
+++ b/configure.in
@@ -68,6 +68,14 @@ dnl Checks for library functions.
 AC_CHECK_FUNCS(strcspn strdup strerror strspn strtol mmap strcasecmp \
    strncasecmp strtol,,[AC_MSG_ERROR("Required function not found")])
 
+dnl Check if the C compiler accepts -Werror
+AC_MSG_CHECKING(if the C compiler accepts -Werror)
+OLDCFLAGS="$CFLAGS"
+CFLAGS="$CFLAGS -Werror"
+AC_TRY_COMPILE(,,AC_MSG_RESULT(yes),[
+   CFLAGS="$OLDCFLAGS"
+   AC_MSG_RESULT(no)])
+
 ##############################################################################
 # 3. Determine libraries we need to include when linking libtorsocks.
 #    OpenBSD and OSX have some special requirements here.

--- a/configure.in
+++ b/configure.in
@@ -666,6 +666,33 @@ fi
   AC_DEFINE_UNQUOTED([PSELECT_SIGNATURE], [${PROTO}],[Description])
   AC_DEFINE_UNQUOTED([PSELECT_ARGNAMES],[${NAMES}],[Argument names])
 
+dnl Find the correct signature for recvfrom
+AC_MSG_CHECKING(for correct recvfrom prototype)
+PROTO=
+TESTPROTO="int s, void * buf, size_t len, int flags, __SOCKADDR_ARG addr, "
+TESTPROTO="${TESTPROTO}socklen_t * addr_len"
+TESTPROTO0="int s, void * buf, size_t len, int flags, "
+TESTPROTO0="${TESTPROTO0}struct sockaddr * __restrict addr, socklen_t * addr_len"
+NAMES='s, buf, len, flags, addr, addr_len'
+for testproto in "${TESTPROTO}" "${TESTPROTO0}"
+do
+  if test "${PROTO}" = ""; then
+    AC_TRY_COMPILE([
+      #include <sys/types.h>
+      #include <sys/socket.h>
+
+      ssize_t recvfrom($testproto);
+    ],,[PROTO="$testproto";],)
+  fi
+done
+if test "${PROTO}" = ""; then
+  AC_MSG_ERROR("no match found!")
+fi
+AC_MSG_RESULT([recvfrom(${PROTO})])
+AC_DEFINE_UNQUOTED(RECVFROM_SIGNATURE, [${PROTO}], [Description])
+AC_DEFINE_UNQUOTED([RECVFROM_ARGNAMES],[${NAMES}],[Argument names])
+
+
 
 case "$host_os" in
 linux*)
@@ -790,13 +817,6 @@ PROTO="int s, const struct msghdr *msg, int flags"
 NAMES='s, msg, flags'
 AC_DEFINE_UNQUOTED(SENDMSG_SIGNATURE, [${PROTO}], [Description])
 AC_DEFINE_UNQUOTED([SENDMSG_ARGNAMES],[${NAMES}],[Argument names])
-
-dnl Emit signature for recvfrom
-PROTO="int s, void * buf, size_t len, int flags, __SOCKADDR_ARG addr, "
-PROTO="${PROTO}socklen_t * addr_len"
-NAMES='s, buf, len, flags, addr, addr_len'
-AC_DEFINE_UNQUOTED(RECVFROM_SIGNATURE, [${PROTO}], [Description])
-AC_DEFINE_UNQUOTED([RECVFROM_ARGNAMES],[${NAMES}],[Argument names])
 
 dnl Emit signature for recvmsg
 PROTO="int s, struct msghdr *msg, int flags"

--- a/configure.in
+++ b/configure.in
@@ -691,6 +691,7 @@ linux*)
     AC_DEFINE_UNQUOTED([PPOLL_ARGNAMES],[],[Argument names])
   else
     AC_MSG_RESULT([ppoll(${PROTO})])
+    AC_DEFINE_UNQUOTED([PPOLL_AVAILABLE], [1],[Description])
     AC_DEFINE_UNQUOTED([PPOLL_SIGNATURE], [${PROTO}],[Description])
     AC_DEFINE_UNQUOTED([PPOLL_ARGNAMES],[${NAMES}],[Argument names])
   fi

--- a/configure.in
+++ b/configure.in
@@ -269,7 +269,8 @@ fi
 #     connect, poll, select, close, getpeername, res_query,
 #     res_init, res_send, res_querydomain, gethostbyname,
 #     gethostbyaddr, getaddrinfo, getipnodebyname, sendto,
-#     sendmsg
+#     sendmsg, recvmsg, read, write, send, recv, recvfrom,
+#     writev, readv, sendmmsg, recvmmsg, ppoll, pselect
 ##############################################################################
 
 dnl Find the correct select prototype on this machine
@@ -332,6 +333,7 @@ case "${PROTO}" in
       ;;
 esac
 AC_DEFINE_UNQUOTED([CONNECT_SOCKARG],[${SOCKETARG}],[Description])
+
 
 dnl Find the correct close prototype on this machine 
 AC_MSG_CHECKING(for correct close prototype)
@@ -480,7 +482,6 @@ AC_MSG_RESULT([getpeername(${PROTO})])
 AC_DEFINE_UNQUOTED(GETPEERNAME_SIGNATURE, [${PROTO}],[Description])
 AC_DEFINE_UNQUOTED([GETPEERNAME_ARGNAMES],[${NAMES}],[Argument names])
 
-
 dnl Find the correct poll prototype on this machine 
 AC_MSG_CHECKING(for correct poll prototype)
 PROTO=
@@ -502,6 +503,252 @@ fi
 AC_MSG_RESULT([poll(${PROTO})])
 AC_DEFINE_UNQUOTED([POLL_SIGNATURE], [${PROTO}],[Description])
 AC_DEFINE_UNQUOTED([POLL_ARGNAMES],[${NAMES}],[Argument names])
+
+
+dnl Find the correct write prototype on this machine 
+AC_MSG_CHECKING(for correct write prototype)
+PROTO=
+NAMES='fd, buf, count'
+for testproto in 'int fd, const void *buf, size_t count'
+do
+  if test "${PROTO}" = ""; then
+    AC_TRY_COMPILE([
+      #include <unistd.h>
+      ssize_t write($testproto);
+    ],,[PROTO="$testproto";],)
+  fi
+done
+if test "${PROTO}" = ""; then
+  AC_MSG_ERROR("no match found!")
+fi
+AC_MSG_RESULT([write(${PROTO})])
+AC_DEFINE_UNQUOTED([WRITE_SIGNATURE], [${PROTO}],[Description])
+AC_DEFINE_UNQUOTED([WRITE_ARGNAMES],[${NAMES}],[Argument names])
+
+dnl Find the correct read prototype on this machine 
+AC_MSG_CHECKING(for correct read prototype)
+PROTO=
+NAMES='fd, buf, count'
+for testproto in 'int fd, void *buf, size_t count' \
+                 'struct pollfd *ufds, nfds_t nfds, int timeout' \
+                 'struct pollfd *ufds, unsigned int nfds, int timeout'
+do
+  if test "${PROTO}" = ""; then
+    AC_TRY_COMPILE([
+      #include <unistd.h>
+      ssize_t read($testproto);
+    ],,[PROTO="$testproto";],)
+  fi
+done
+if test "${PROTO}" = ""; then
+  AC_MSG_ERROR("no match found!")
+fi
+AC_MSG_RESULT([read(${PROTO})])
+AC_DEFINE_UNQUOTED([READ_SIGNATURE], [${PROTO}],[Description])
+AC_DEFINE_UNQUOTED([READ_ARGNAMES],[${NAMES}],[Argument names])
+
+dnl Find the correct send prototype on this machine 
+AC_MSG_CHECKING(for correct send prototype)
+PROTO=
+NAMES='fd, buf, count, flags'
+for testproto in 'int fd, const void *buf, size_t count, int flags' \
+                 'struct pollfd *ufds, nfds_t nfds, int timeout' \
+                 'struct pollfd *ufds, unsigned int nfds, int timeout'
+do
+  if test "${PROTO}" = ""; then
+    AC_TRY_COMPILE([
+      #include <sys/types.h>
+      #include <sys/socket.h>
+      ssize_t send($testproto);
+    ],,[PROTO="$testproto";],)
+  fi
+done
+if test "${PROTO}" = ""; then
+  AC_MSG_ERROR("no match found!")
+fi
+AC_MSG_RESULT([send(${PROTO})])
+AC_DEFINE_UNQUOTED([SEND_SIGNATURE], [${PROTO}],[Description])
+AC_DEFINE_UNQUOTED([SEND_ARGNAMES],[${NAMES}],[Argument names])
+
+dnl Find the correct recv prototype on this machine 
+AC_MSG_CHECKING(for correct recv prototype)
+PROTO=
+NAMES='fd, buf, count, flags'
+for testproto in 'int fd, void *buf, size_t count, int flags' \
+                 'struct pollfd *ufds, nfds_t nfds, int timeout' \
+                 'struct pollfd *ufds, unsigned int nfds, int timeout'
+do
+  if test "${PROTO}" = ""; then
+    AC_TRY_COMPILE([
+      #include <sys/types.h>
+      #include <sys/socket.h>
+      ssize_t recv($testproto);
+    ],,[PROTO="$testproto";],)
+  fi
+done
+if test "${PROTO}" = ""; then
+  AC_MSG_ERROR("no match found!")
+fi
+AC_MSG_RESULT([recv(${PROTO})])
+AC_DEFINE_UNQUOTED([RECV_SIGNATURE], [${PROTO}],[Description])
+AC_DEFINE_UNQUOTED([RECV_ARGNAMES],[${NAMES}],[Argument names])
+
+dnl Find the correct readv prototype on this machine 
+AC_MSG_CHECKING(for correct readv prototype)
+PROTO=
+NAMES='fd, iov, iovcnt'
+for testproto in 'int fd, const struct iovec *iov, int iovcnt' \
+                 'struct pollfd *ufds, nfds_t nfds, int timeout' \
+                 'struct pollfd *ufds, unsigned int nfds, int timeout'
+do
+  if test "${PROTO}" = ""; then
+    AC_TRY_COMPILE([
+      #include <sys/uio.h>
+      ssize_t readv($testproto);
+    ],,[PROTO="$testproto";],)
+  fi
+done
+if test "${PROTO}" = ""; then
+  AC_MSG_ERROR("no match found!")
+fi
+AC_MSG_RESULT([readv(${PROTO})])
+AC_DEFINE_UNQUOTED([READV_SIGNATURE], [${PROTO}],[Description])
+AC_DEFINE_UNQUOTED([READV_ARGNAMES],[${NAMES}],[Argument names])
+
+dnl Find the correct writev prototype on this machine 
+AC_MSG_CHECKING(for correct writev prototype)
+PROTO=
+NAMES='fd, iov, iovcnt'
+for testproto in 'int fd, const struct iovec *iov, int iovcnt' \
+                 'struct pollfd *ufds, nfds_t nfds, int timeout' \
+                 'struct pollfd *ufds, unsigned int nfds, int timeout'
+do
+  if test "${PROTO}" = ""; then
+    AC_TRY_COMPILE([
+      #include <sys/uio.h>
+      ssize_t writev($testproto);
+    ],,[PROTO="$testproto";],)
+  fi
+done
+if test "${PROTO}" = ""; then
+  AC_MSG_ERROR("no match found!")
+fi
+AC_MSG_RESULT([writev(${PROTO})])
+AC_DEFINE_UNQUOTED([WRITEV_SIGNATURE], [${PROTO}],[Description])
+AC_DEFINE_UNQUOTED([WRITEV_ARGNAMES],[${NAMES}],[Argument names])
+
+
+dnl Find the correct pselect prototype on this machine 
+AC_MSG_CHECKING(for correct pselect prototype)
+PROTO=
+NAMES='nfds, readfds, writefds, exceptfds, timeout, sigmask'
+TESTPROTO='int nfds, fd_set * readfds, '
+TESTPROTO="${TESTPROTO}fd_set * writefds, "
+TESTPROTO="${TESTPROTO}fd_set * exceptfds, "
+TESTPROTO="${TESTPROTO}const struct timespec * timeout, "
+TESTPROTO="${TESTPROTO}const sigset_t * sigmask"
+for testproto in "${TESTPROTO}"
+do
+  if test "${PROTO}" = ""; then
+    AC_TRY_COMPILE([
+      #include <sys/time.h>
+      #include <sys/types.h>
+      #include <unistd.h>
+      int pselect($testproto);
+    ],,[PROTO="$testproto";],)
+  fi
+done
+if test "${PROTO}" = ""; then
+  AC_MSG_ERROR("no match found!")
+fi
+  AC_MSG_RESULT([pselect(${PROTO})])
+  AC_DEFINE_UNQUOTED([PSELECT_SIGNATURE], [${PROTO}],[Description])
+  AC_DEFINE_UNQUOTED([PSELECT_ARGNAMES],[${NAMES}],[Argument names])
+
+
+case "$host_os" in
+linux*)
+  dnl Find the correct ppoll prototype on this machine 
+  AC_MSG_CHECKING(for correct ppoll prototype)
+  PROTO=
+  NAMES='fds, nfds, timeout, sigmask'
+  TESTPROTO='struct pollfd *fds, nfds_t nfds, '
+  TESTPROTO="${TESTPROTO}const struct timespec *timeout, "
+  TESTPROTO="${TESTPROTO}const __sigset_t *sigmask"
+  for testproto in "${TESTPROTO}"
+  do
+    if test "${PROTO}" = ""; then
+      AC_TRY_COMPILE([
+        #define _GNU_SOURCE
+        #include <sys/poll.h>
+        int ppoll(${testproto});
+      ],,[PROTO="${testproto}";],)
+    fi
+  done
+  if test "${PROTO}" = ""; then
+    AC_MSG_RESULT(not found/supported)
+    AC_DEFINE_UNQUOTED([PPOLL_SIGNATURE], [void],[Description])
+    AC_DEFINE_UNQUOTED([PPOLL_ARGNAMES],[],[Argument names])
+  else
+    AC_MSG_RESULT([ppoll(${PROTO})])
+    AC_DEFINE_UNQUOTED([PPOLL_SIGNATURE], [${PROTO}],[Description])
+    AC_DEFINE_UNQUOTED([PPOLL_ARGNAMES],[${NAMES}],[Argument names])
+  fi
+
+  dnl Find the correct sendmmsg prototype on this machine
+  AC_MSG_CHECKING(for correct sendmmsg prototype)
+  PROTO=
+  NAMES='s, msgvec, vlen, flags'
+  for testproto in 'int s, struct mmsghdr *msgvec, unsigned int vlen, int flags'
+  do
+    if test "${PROTO}" = ""; then
+      AC_TRY_COMPILE([
+        #define _GNU_SOURCE
+        #include <sys/socket.h>
+        int sendmmsg($testproto);
+      ],,[PROTO="$testproto";],)
+    fi
+  done
+  if test "${PROTO}" = ""; then
+    AC_MSG_RESULT(not found/supported)
+  else
+    AC_MSG_RESULT([sendmmsg(${PROTO})])
+    AC_DEFINE_UNQUOTED(SENDMMSG_SIGNATURE, [${PROTO}], [Description])
+    AC_DEFINE_UNQUOTED([SENDMMSG_ARGNAMES],[${NAMES}],[Argument names])
+    AC_DEFINE_UNQUOTED(SENDMMSG_AVAILABLE, [${PROTO}], [Description])
+  fi
+
+
+  dnl Find the correct recvmmsg prototype on this machine
+  AC_MSG_CHECKING(for correct recvmmsg prototype)
+  PROTO=
+  NAMES='s, msgvec, vlen, flags, timeout'
+  TESTPROTO='int s, struct mmsghdr *msgvec, unsigned int vlen, int flags, '
+  TESTPROTO="${TESTPROTO}const struct timespec *timeout"
+  for testproto in "${TESTPROTO}"
+  do
+    if test "${PROTO}" = ""; then
+      AC_TRY_COMPILE([
+        #define _GNU_SOURCE
+        #include <sys/socket.h>
+        int recvmmsg($testproto);
+      ],,[PROTO="$testproto";],)
+    fi
+  done
+  if test "${PROTO}" = ""; then
+    AC_MSG_RESULT(not found/supported)
+  else
+    AC_MSG_RESULT([recvmmsg(${PROTO})])
+    AC_DEFINE_UNQUOTED(RECVMMSG_SIGNATURE, [${PROTO}], [Description])
+    AC_DEFINE_UNQUOTED([RECVMMSG_ARGNAMES],[${NAMES}],[Argument names])
+    AC_DEFINE_UNQUOTED(RECVMMSG_AVAILABLE, [${PROTO}], [Description])
+  fi
+  ;;
+*)
+    AC_DEFINE_UNQUOTED([PPOLL_SIGNATURE], [void],[Description])
+    AC_DEFINE_UNQUOTED([PPOLL_ARGNAMES],[],[Argument names])
+  ;;
+esac
 
 dnl Emit signature for gethostbyname
 PROTO="const char *name"
@@ -528,7 +775,8 @@ AC_DEFINE_UNQUOTED(GETHOSTBYADDR_SIGNATURE, [${PROTO}], [Description])
 AC_DEFINE_UNQUOTED([GETHOSTBYADDR_ARGNAMES],[${NAMES}],[Argument names])
 
 dnl Emit signature for sendto
-PROTO="int s, const void *buf, size_t len, int flags, const struct sockaddr *to, socklen_t tolen"
+PROTO="int s, const void *buf, size_t len, int flags, "
+PROTO="${PROTO}const struct sockaddr *to, socklen_t tolen"
 NAMES='s, buf, len, flags, to, tolen'
 AC_DEFINE_UNQUOTED(SENDTO_SIGNATURE, [${PROTO}], [Description])
 AC_DEFINE_UNQUOTED([SENDTO_ARGNAMES],[${NAMES}],[Argument names])
@@ -538,6 +786,19 @@ PROTO="int s, const struct msghdr *msg, int flags"
 NAMES='s, msg, flags'
 AC_DEFINE_UNQUOTED(SENDMSG_SIGNATURE, [${PROTO}], [Description])
 AC_DEFINE_UNQUOTED([SENDMSG_ARGNAMES],[${NAMES}],[Argument names])
+
+dnl Emit signature for recvfrom
+PROTO="int s, void * buf, size_t len, int flags, __SOCKADDR_ARG addr, "
+PROTO="${PROTO}socklen_t * addr_len"
+NAMES='s, buf, len, flags, addr, addr_len'
+AC_DEFINE_UNQUOTED(RECVFROM_SIGNATURE, [${PROTO}], [Description])
+AC_DEFINE_UNQUOTED([RECVFROM_ARGNAMES],[${NAMES}],[Argument names])
+
+dnl Emit signature for recvmsg
+PROTO="int s, struct msghdr *msg, int flags"
+NAMES='s, msg, flags'
+AC_DEFINE_UNQUOTED(RECVMSG_SIGNATURE, [${PROTO}], [Description])
+AC_DEFINE_UNQUOTED([RECVMSG_ARGNAMES],[${NAMES}],[Argument names])
 
 
 ##############################################################################

--- a/src/dead_pool.h
+++ b/src/dead_pool.h
@@ -27,6 +27,8 @@
 extern int (*realconnect)(CONNECT_SIGNATURE);
 extern int (*realclose)(CLOSE_SIGNATURE);
 extern int (*realgetaddrinfo)(GETADDRINFO_SIGNATURE);
+extern ssize_t (*realsend)(SEND_SIGNATURE);
+extern ssize_t (*realrecv)(RECV_SIGNATURE);
 
 struct struct_pool_ent {
   unsigned int ip;

--- a/src/expansion_table.h
+++ b/src/expansion_table.h
@@ -41,6 +41,12 @@
 #define DNS_FUNCD32 FUNCD32
 #define DNS_FUNCD64 FUNCD64
 
+#ifdef SENDMMSG_AVAILABLE
+#define DNS_FUNCDL(e,r,s,n,b,m)            PATCH_TABLE_EXPANSION(e,r,s,n,b,m)
+#else
+#define DNS_FUNCDL(e,r,s,n,b,m)            EMPTY_FUNC(e,r,s,n,b,m)
+#endif /* SENDMMSG_AVAILABLE */
+
 #define EMPTY_FUNC(e,r,s,n,b,m)
 
 #if defined(__APPLE__) || defined(__darwin__)
@@ -95,6 +101,18 @@ DNS_FUNCD32 (ERR,    ssize_t,            SENDMSG_,           sendmsg_unix2003,  
 DNS_FUNCD32 (ERR,    ssize_t,            SENDMSG_,           sendmsg_nocancel_unix2003,     sendmsg,             "sendmsg$NOCANCEL$UNIX2003")
 DNS_FUNCD64 (ERR,    ssize_t,            SENDMSG_,           sendmsg_nocancel,              sendmsg,             "sendmsg$NOCANCEL")
 
+DNS_FUNCDL  (ERR,    int,                SENDMMSG_,          sendmmsg,                      sendmmsg,            "sendmmsg")
+
+DNS_FUNCDL  (ERR,    int,                RECVMMSG_,          recvmmsg,                      recvmmsg,            "recvmmsg")
+
+DNS_FUNC    (ERR,    ssize_t,            RECVFROM_,          recvfrom,                      recvfrom,            "recvfrom")
+
+DNS_FUNC    (ERR,    ssize_t,            RECVMSG_,           recvmsg,                       recvmsg,             "recvmsg")
+
+FUNC        (ERR,    ssize_t,            SEND_,              send,                          send,                "send")
+
+FUNC        (ERR,    ssize_t,            RECV_,              recv,                          recv,                "recv")
+
 FUNC        (ERR,    int,                CONNECT_,           connect,                       connect,             "connect")
 FUNCD32     (ERR,    int,                CONNECT_,           connect_unix2003,              connect,             "connect$UNIX2003")
 FUNCD32     (ERR,    int,                CONNECT_,           connect_nocancel_unix2003,     connect,             "connect$NOCANCEL$UNIX2003")
@@ -123,3 +141,18 @@ FUNCD64     (ERR,    int,                CLOSE_,             close_nocancel,    
 
 FUNC        (ERR,    int,                GETPEERNAME_,       getpeername,                   getpeername,         "getpeername")
 FUNCD32     (ERR,    int,                GETPEERNAME_,       getpeername_unix2003,          getpeername,         "getpeername$UNIX2003")
+
+FUNC        (ERR,    ssize_t,            READ_,              read,                          read,                "read")
+
+FUNC        (ERR,    ssize_t,            READV_,             readv,                         readv,               "readv")
+
+FUNC        (ERR,    ssize_t,            WRITE_,             write,                         write,               "write")
+
+FUNC        (ERR,    ssize_t,            WRITEV_,            writev,                        writev,               "writev")
+
+FUNC        (ERR,    int,                PSELECT_,           pselect,                       pselect,              "pselect")
+
+#if PPOLL_AVAILABLE
+FUNC        (ERR,    int,                PPOLL_,             ppoll,                         ppoll,                "ppoll")
+#endif /* PPOLL_AVAILABLE */
+/* XXX Are pread/pwrite/preadv/pwritev usable with no offset?? */

--- a/src/parser.h
+++ b/src/parser.h
@@ -37,6 +37,7 @@ struct serverent {
     char *defuser;            /* Default username for this socks server */
     char *defpass;            /* Default password for this socks server */
     struct netent *reachnets; /* Linked list of nets from this server */
+    int use_optdata;          /* Use optimistic data */
     struct serverent *next;   /* Pointer to next server entry */
 };
 

--- a/src/socks.h
+++ b/src/socks.h
@@ -75,6 +75,8 @@ struct connreq {
    unsigned int datadone;
    char buffer[2048];
 
+   int using_optdata;
+
    struct connreq *next;
 };
 

--- a/src/torsocks.c
+++ b/src/torsocks.c
@@ -684,6 +684,8 @@ inline int torsocks_poll_common(struct pollfd * ufds, nfds_t nfds,
         for (i = 0; i < nfds; i++) {
             if (!(conn = find_socks_request(ufds[i].fd, 0)))
                 continue;
+            
+	    show_msg(MSGDEBUG, "Found our request, %x\n", conn);
 
             /* We always want to know about socket exceptions but they're
               * always returned (i.e they don't need to be in the list of
@@ -696,8 +698,10 @@ inline int torsocks_poll_common(struct pollfd * ufds, nfds_t nfds,
                 ufds[i].events |= POLLOUT;
             /* If we're waiting to receive data we want to get
               * read events */
-            if (conn->state == RECEIVING)
+            if (conn->state == RECEIVING || conn->state == SENTV4REQ || conn->state == SENTV5CONNECT)
                 ufds[i].events |= POLLIN;
+
+            show_msg(MSGDEBUG, "Events on socket are %d\n", ufds[i].events);
         }
 
 	if (opts.is_poll)

--- a/src/torsocks.c
+++ b/src/torsocks.c
@@ -775,6 +775,8 @@ inline int torsocks_poll_common(struct pollfd * ufds, nfds_t nfds,
                  * leaves us a bit hamstrung.
                  * We don't delete the request so that hopefully we can
                  * return the error on the socket if they call connect() on it */
+            } else if (conn->state == DONE) {
+                kill_socks_request(conn);
             } else {
                 /* The connection is done,  if the client polled for
                  * writing we can go ahead and signal that now (since the socket must

--- a/src/torsocks.c
+++ b/src/torsocks.c
@@ -471,6 +471,9 @@ inline int torsocks_select_common(int nfds, fd_set * writefds, fd_set * readfds,
             if ((conn->state == FAILED) || (conn->state == DONE) ||
                 (conn->selectevents == 0))
                 continue;
+
+	    show_msg(MSGDEBUG, "Found our request, %x\n", conn);
+
             /* We always want to know about socket exceptions */
             FD_SET(conn->sockid, &myexceptfds);
             /* If we're waiting for a connect or to be able to send
@@ -481,16 +484,25 @@ inline int torsocks_select_common(int nfds, fd_set * writefds, fd_set * readfds,
                 FD_CLR(conn->sockid,&mywritefds);
             /* If we're waiting to receive data we want to get
               * read events */
-            if (conn->state == RECEIVING)
+            if (conn->state == RECEIVING || conn->state == SENTV4REQ ||
+                conn->state == SENTV5CONNECT || conn->state == CONNECTING)
                 FD_SET(conn->sockid,&myreadfds);
             else
                 FD_CLR(conn->sockid,&myreadfds);
+
+            show_msg(MSGDEBUG, "Events on socket are read: %d, "
+	                       "write %d, except %d\n",
+			       (FD_ISSET(conn->sockid, &myreadfds) ? 1 : 0),
+			       (FD_ISSET(conn->sockid, &mywritefds) ? 1 : 0),
+			       (FD_ISSET(conn->sockid, &myexceptfds) ? 1 : 0));
         }
 
         if (opts.is_select)
-          nevents = original_select(nfds, readfds, writefds, exceptfds, opts.select_timeout);
+          nevents = original_select(nfds, &myreadfds, &mywritefds, &myexceptfds, opts.select_timeout);
         else
-          nevents = original_pselect(nfds, readfds, writefds, exceptfds, opts.pselect_timeout, opts.sigmask);
+          nevents = original_pselect(nfds, &myreadfds, &mywritefds, &myexceptfds, opts.pselect_timeout, opts.sigmask);
+        
+	show_msg(MSGDEBUG, "%s returned with %d\n", (opts.is_select ? "select" : "pselect"), nevents);
 
         /* If there were no events we must have timed out or had an error */
         if (nevents <= 0)
@@ -566,6 +578,8 @@ inline int torsocks_select_common(int nfds, fd_set * writefds, fd_set * readfds,
                 * leaves us a bit hamstrung.
                 * We don't delete the request so that hopefully we can
                 * return the error on the socket if they call connect() on it */
+            } else if (conn->state == DONE) {
+                kill_socks_request(conn);
             } else {
                 /* The connection is done,  if the client selected for
                 * writing we can go ahead and signal that now (since the socket must

--- a/src/torsocks.c
+++ b/src/torsocks.c
@@ -306,7 +306,7 @@ int torsocks_connect_guts(CONNECT_SIGNATURE, int (*original_connect)(CONNECT_SIG
     }
 
     /* If this is an INET6, we'll refuse it. */
-    if ((connaddr->sin_family == AF_INET6)) {
+    if (connaddr->sin_family == AF_INET6) {
        show_msg(MSGERR, "connect: Connection is IPv6: rejecting.\n");
        errno = EAFNOSUPPORT;
        return -1;

--- a/src/torsocks.c
+++ b/src/torsocks.c
@@ -702,8 +702,13 @@ inline int torsocks_poll_common(struct pollfd * ufds, nfds_t nfds,
 
 	if (opts.is_poll)
             nevents = original_poll(ufds, nfds, opts.poll_timeout);
+	#ifdef PPOLL_AVAILABLE
         else
             nevents = original_ppoll(ufds, nfds, opts.ppoll_timeout_ts, opts.sigmask);
+	#endif /* PPOLL_AVAILABLE */
+        
+	show_msg(MSGDEBUG, "%s returned with %d\n", (opts.is_poll ? "poll" : "ppoll"), nevents);
+
         /* If there were no events we must have timed out or had an error */
         if (nevents <= 0)
             break;

--- a/src/torsocks.c
+++ b/src/torsocks.c
@@ -101,6 +101,16 @@ struct selectopts {
   const sigset_t * sigmask;
 };
 
+struct pollopts {
+  int is_poll;
+  union {
+    int poll_timeout;
+    const struct timespec * ppoll_timeout_ts;
+  };
+  const sigset_t * sigmask;
+};
+
+
 /* Exported Function Prototypes */
 void __attribute__ ((constructor)) torsocks_init(void);
 
@@ -651,40 +661,15 @@ int torsocks_select_guts(SELECT_SIGNATURE, int (*original_select)(SELECT_SIGNATU
     return(nevents);
 }
 
-int torsocks_poll_guts(POLL_SIGNATURE, int (*original_poll)(POLL_SIGNATURE))
+/* Common functionality of poll and ppoll */
+inline int torsocks_poll_common(struct pollfd * ufds, nfds_t nfds, 
+                 int (*original_poll)(POLL_SIGNATURE),
+                 int (*original_ppoll)(PPOLL_SIGNATURE), struct pollopts opts)
 {
     int nevents = 0;
-    int rc = 0;
     unsigned int i;
     int setevents = 0;
-    int monitoring = 0;
     struct connreq *conn, *nextconn;
-
-    /* If we're not currently managing any requests we can just
-      * leave here */
-    if (!requests)
-        return(original_poll(ufds, nfds, timeout));
-
-    show_msg(MSGTEST, "Intercepted call to poll\n");
-    show_msg(MSGDEBUG, "Intercepted call to poll with %d fds, "
-              "0x%08x timeout %d\n", nfds, ufds, timeout);
-
-    for (conn = requests; conn != NULL; conn = conn->next)
-        conn->selectevents = 0;
-
-    /* Record what events on our sockets the caller was interested
-      * in */
-    for (i = 0; i < nfds; i++) {
-        if (!(conn = find_socks_request(ufds[i].fd, 0)))
-            continue;
-        show_msg(MSGDEBUG, "Have event checks for socks enabled socket %d\n",
-                conn->sockid);
-        conn->selectevents = ufds[i].events;
-        monitoring = 1;
-    }
-
-    if (!monitoring)
-        return(original_poll(ufds, nfds, timeout));
 
     /* This is our poll loop. In it we repeatedly call poll(). We
       * pass select the same event list as provided by the caller except we
@@ -715,7 +700,10 @@ int torsocks_poll_guts(POLL_SIGNATURE, int (*original_poll)(POLL_SIGNATURE))
                 ufds[i].events |= POLLIN;
         }
 
-        nevents = original_poll(ufds, nfds, timeout);
+	if (opts.is_poll)
+            nevents = original_poll(ufds, nfds, opts.poll_timeout);
+        else
+            nevents = original_ppoll(ufds, nfds, opts.ppoll_timeout_ts, opts.sigmask);
         /* If there were no events we must have timed out or had an error */
         if (nevents <= 0)
             break;
@@ -760,7 +748,7 @@ int torsocks_poll_guts(POLL_SIGNATURE, int (*original_poll)(POLL_SIGNATURE))
             if (setevents & (POLLERR | POLLNVAL | POLLHUP)) {
                 conn->state = FAILED;
             } else {
-                rc = handle_request(conn);
+                handle_request(conn);
             }
             /* If the connection hasn't failed or completed there is nothing
               * to report to the client */
@@ -785,7 +773,7 @@ int torsocks_poll_guts(POLL_SIGNATURE, int (*original_poll)(POLL_SIGNATURE))
             } else {
                 /* The connection is done,  if the client polled for
                  * writing we can go ahead and signal that now (since the socket must
-                 * be ready for writing), otherwise we'll just let the select loop
+                 * be ready for writing), otherwise we'll just let the poll loop
                  * come around again (since we can't flag it for read, we don't know
                  * if there is any data to be read and can't be bothered checking) */
                 if (conn->selectevents & POLLOUT) {
@@ -805,7 +793,45 @@ int torsocks_poll_guts(POLL_SIGNATURE, int (*original_poll)(POLL_SIGNATURE))
         ufds[i].events = conn->selectevents;
     }
 
-    return(nevents);
+    return nevents;
+}
+
+int torsocks_poll_guts(POLL_SIGNATURE, int (*original_poll)(POLL_SIGNATURE))
+{
+    unsigned int i;
+    int monitoring = 0;
+    struct connreq *conn;
+    struct pollopts opts;
+
+    /* If we're not currently managing any requests we can just
+      * leave here */
+    if (!requests)
+        return(original_poll(ufds, nfds, timeout));
+
+    show_msg(MSGTEST, "Intercepted call to poll\n");
+    show_msg(MSGDEBUG, "Intercepted call to poll with %d fds, "
+              "0x%08x timeout %d\n", nfds, ufds, timeout);
+
+    for (conn = requests; conn != NULL; conn = conn->next)
+        conn->selectevents = 0;
+
+    /* Record what events on our sockets the caller was interested
+      * in */
+    for (i = 0; i < nfds; i++) {
+        if (!(conn = find_socks_request(ufds[i].fd, 0)))
+            continue;
+        show_msg(MSGDEBUG, "Have event checks for socks enabled socket %d\n",
+                conn->sockid);
+        conn->selectevents = ufds[i].events;
+        monitoring = 1;
+    }
+
+    if (!monitoring)
+        return(original_poll(ufds, nfds, timeout));
+
+    opts.is_poll = 1;
+    opts.poll_timeout = timeout;
+    return torsocks_poll_common(ufds, nfds, original_poll, NULL, opts);
 }
 
 int torsocks_close_guts(CLOSE_SIGNATURE, int (*original_close)(CLOSE_SIGNATURE))

--- a/src/torsocks.c
+++ b/src/torsocks.c
@@ -1286,7 +1286,7 @@ ssize_t torsocks_read_guts(READ_SIGNATURE, ssize_t(*original_read)(READ_SIGNATUR
 	handle_request(conn);
 
         if (conn->state != DONE) {
-            errno = ENOTCONN;
+            errno = EBADF;
             return(-1);
         }
     }
@@ -1363,7 +1363,7 @@ ssize_t torsocks_readv_guts(READV_SIGNATURE, ssize_t(*original_readv)(READV_SIGN
 	handle_request(conn);
 
         if (conn->state != DONE) {
-            errno = ENOTCONN;
+            errno = EBADF;
             return(-1);
         }
     }

--- a/src/torsocks.c
+++ b/src/torsocks.c
@@ -1110,6 +1110,12 @@ ssize_t torsocks_sendmsg_guts(SENDMSG_SIGNATURE, ssize_t (*original_sendmsg)(SEN
 #ifdef SENDMMSG_AVAILABLE
 int torsocks_sendmmsg_guts(SENDMMSG_SIGNATURE, int (*original_sendmmsg)(SENDMMSG_SIGNATURE))
 {
+    /* If the real sendmmsg doesn't exist, we're stuffed */
+    if (original_sendmmsg == NULL) {
+        show_msg(MSGERR, "Unresolved symbol: sendmmsg\n");
+        return(-1);
+    }
+
     return original_sendmmsg(s, msgvec, vlen, flags);
 }
 #endif /* SENDMMSG_AVAILABLE */
@@ -1117,58 +1123,124 @@ int torsocks_sendmmsg_guts(SENDMMSG_SIGNATURE, int (*original_sendmmsg)(SENDMMSG
 #ifdef RECVMMSG_AVAILABLE
 int torsocks_recvmmsg_guts(RECVMMSG_SIGNATURE, int (*original_recvmmsg)(RECVMMSG_SIGNATURE))
 {
+    /* If the real recvmmsg doesn't exist, we're stuffed */
+    if (original_recvmmsg == NULL) {
+        show_msg(MSGERR, "Unresolved symbol: recvmmsg\n");
+        return(-1);
+    }
+
     return original_recvmmsg(s, msgvec, vlen, flags, timeout);
 }
 #endif /* RECVMMSG_AVAILABLE */
 
 ssize_t torsocks_recvfrom_guts(RECVFROM_SIGNATURE, ssize_t(*original_recvfrom)(RECVFROM_SIGNATURE))
 {
+    /* If the real recvfrom doesn't exist, we're stuffed */
+    if (original_recvfrom == NULL) {
+        show_msg(MSGERR, "Unresolved symbol: recvfrom\n");
+        return(-1);
+    }
+
     return (ssize_t) original_recvfrom(s, buf, len, flags, addr, addr_len);
 }
 
 ssize_t torsocks_recvmsg_guts(RECVMSG_SIGNATURE, ssize_t(*original_recvmsg)(RECVMSG_SIGNATURE))
 {
+    /* If the real recvmsg doesn't exist, we're stuffed */
+    if (original_recvmsg == NULL) {
+        show_msg(MSGERR, "Unresolved symbol: recvmsg\n");
+        return(-1);
+    }
+
     return (ssize_t) original_recvmsg(s, msg, flags);
 }
 
 ssize_t torsocks_write_guts(WRITE_SIGNATURE, ssize_t(*original_write)(WRITE_SIGNATURE))
 {
+    /* If the real write doesn't exist, we're stuffed */
+    if (original_write == NULL) {
+        show_msg(MSGERR, "Unresolved symbol: write\n");
+        return(-1);
+    }
+
     return original_write(fd, buf, count);
 }
 
 ssize_t torsocks_read_guts(READ_SIGNATURE, ssize_t(*original_read)(READ_SIGNATURE))
 {
+    /* If the real read doesn't exist, we're stuffed */
+    if (original_read == NULL) {
+        show_msg(MSGERR, "Unresolved symbol: read\n");
+        return(-1);
+    }
+
     return original_read(fd, buf, count);
 }
 
 ssize_t torsocks_send_guts(SEND_SIGNATURE, ssize_t(*original_send)(SEND_SIGNATURE))
 {
+    /* If the real send doesn't exist, we're stuffed */
+    if (original_send == NULL) {
+        show_msg(MSGERR, "Unresolved symbol: send\n");
+        return(-1);
+    }
+
     return original_send(fd, buf, count, flags);
 }
 
 ssize_t torsocks_recv_guts(RECV_SIGNATURE, ssize_t(*original_recv)(RECV_SIGNATURE))
 {
+    /* If the real recv doesn't exist, we're stuffed */
+    if (original_recv == NULL) {
+        show_msg(MSGERR, "Unresolved symbol: recv\n");
+        return(-1);
+    }
+
     return original_recv(fd, buf, count, flags);
 }
 
 ssize_t torsocks_readv_guts(READV_SIGNATURE, ssize_t(*original_readv)(READV_SIGNATURE))
 {
+    /* If the real readv doesn't exist, we're stuffed */
+    if (original_readv == NULL) {
+        show_msg(MSGERR, "Unresolved symbol: readv\n");
+        return(-1);
+    }
+
     return original_readv(fd, iov, iovcnt);
 }
 
 ssize_t torsocks_writev_guts(WRITEV_SIGNATURE, ssize_t(*original_writev)(WRITEV_SIGNATURE))
 {
+    /* If the real writev doesn't exist, we're stuffed */
+    if (original_writev == NULL) {
+        show_msg(MSGERR, "Unresolved symbol: writev\n");
+        return(-1);
+    }
+
     return original_writev(fd, iov, iovcnt);
 }
 
 #if PPOLL_AVAILABLE
 int torsocks_ppoll_guts(PPOLL_SIGNATURE, int(*original_ppoll)(PPOLL_SIGNATURE))
 {
+    /* If the real ppoll doesn't exist, we're stuffed */
+    if (original_ppoll == NULL) {
+        show_msg(MSGERR, "Unresolved symbol: ppoll\n");
+        return(-1);
+    }
+
     return original_ppoll(fds, nfds, timeout, sigmask);
 }
 #endif /* PPOLL_AVAILABLE */
 
 int torsocks_pselect_guts(PSELECT_SIGNATURE, int(*original_pselect)(PSELECT_SIGNATURE))
 {
+    /* If the real pselect doesn't exist, we're stuffed */
+    if (original_pselect == NULL) {
+        show_msg(MSGERR, "Unresolved symbol: pselect\n");
+        return(-1);
+    }
+
     return original_pselect(nfds, readfds, writefds, exceptfds, timeout, sigmask);
 }

--- a/src/torsocks.c
+++ b/src/torsocks.c
@@ -1106,3 +1106,69 @@ ssize_t torsocks_sendmsg_guts(SENDMSG_SIGNATURE, ssize_t (*original_sendmsg)(SEN
     return (ssize_t) original_sendmsg(s, msg, flags);
 }
 
+/* TODO Add MMSG_AVAILABLE */
+#ifdef SENDMMSG_AVAILABLE
+int torsocks_sendmmsg_guts(SENDMMSG_SIGNATURE, int (*original_sendmmsg)(SENDMMSG_SIGNATURE))
+{
+    return original_sendmmsg(s, msgvec, vlen, flags);
+}
+#endif /* SENDMMSG_AVAILABLE */
+
+#ifdef RECVMMSG_AVAILABLE
+int torsocks_recvmmsg_guts(RECVMMSG_SIGNATURE, int (*original_recvmmsg)(RECVMMSG_SIGNATURE))
+{
+    return original_recvmmsg(s, msgvec, vlen, flags, timeout);
+}
+#endif /* RECVMMSG_AVAILABLE */
+
+ssize_t torsocks_recvfrom_guts(RECVFROM_SIGNATURE, ssize_t(*original_recvfrom)(RECVFROM_SIGNATURE))
+{
+    return (ssize_t) original_recvfrom(s, buf, len, flags, addr, addr_len);
+}
+
+ssize_t torsocks_recvmsg_guts(RECVMSG_SIGNATURE, ssize_t(*original_recvmsg)(RECVMSG_SIGNATURE))
+{
+    return (ssize_t) original_recvmsg(s, msg, flags);
+}
+
+ssize_t torsocks_write_guts(WRITE_SIGNATURE, ssize_t(*original_write)(WRITE_SIGNATURE))
+{
+    return original_write(fd, buf, count);
+}
+
+ssize_t torsocks_read_guts(READ_SIGNATURE, ssize_t(*original_read)(READ_SIGNATURE))
+{
+    return original_read(fd, buf, count);
+}
+
+ssize_t torsocks_send_guts(SEND_SIGNATURE, ssize_t(*original_send)(SEND_SIGNATURE))
+{
+    return original_send(fd, buf, count, flags);
+}
+
+ssize_t torsocks_recv_guts(RECV_SIGNATURE, ssize_t(*original_recv)(RECV_SIGNATURE))
+{
+    return original_recv(fd, buf, count, flags);
+}
+
+ssize_t torsocks_readv_guts(READV_SIGNATURE, ssize_t(*original_readv)(READV_SIGNATURE))
+{
+    return original_readv(fd, iov, iovcnt);
+}
+
+ssize_t torsocks_writev_guts(WRITEV_SIGNATURE, ssize_t(*original_writev)(WRITEV_SIGNATURE))
+{
+    return original_writev(fd, iov, iovcnt);
+}
+
+#if PPOLL_AVAILABLE
+int torsocks_ppoll_guts(PPOLL_SIGNATURE, int(*original_ppoll)(PPOLL_SIGNATURE))
+{
+    return original_ppoll(fds, nfds, timeout, sigmask);
+}
+#endif /* PPOLL_AVAILABLE */
+
+int torsocks_pselect_guts(PSELECT_SIGNATURE, int(*original_pselect)(PSELECT_SIGNATURE))
+{
+    return original_pselect(nfds, readfds, writefds, exceptfds, timeout, sigmask);
+}

--- a/test/test_torsocks.c
+++ b/test/test_torsocks.c
@@ -141,6 +141,7 @@ static int icmp_test()
     return(0);
 }
 
+#if 0
 static char *txtquery(const char *domain, unsigned int *ttl)
 {
     unsigned char answer[PACKETSZ], *answend, *pt;
@@ -236,6 +237,7 @@ static char *txtquery(const char *domain, unsigned int *ttl)
 
     return txt;
 }
+#endif
 
 static int res_tests(char *ip, char *test) {
     unsigned char dnsreply[1024];


### PR DESCRIPTION
Add support for Torsocks to provide optimistic data, by default, during the SOCKS handshake.

Overload write/read/send/recv/writev/readv/sendmmsg/recvmmsg/recvmsg/recvfrom
Overload pselect/ppoll
