### PR TITLE
Implement local_connect_enable option

### DIFF
--- a/doc/torsocks.conf.5.in
+++ b/doc/torsocks.conf.5.in
@@ -158,6 +158,14 @@ range 150.0.0.0 to 150.255.255.255 when the connection request is for ports
 80-1024.
 
 .TP
+.I local_connect_enable
+This allows the application to connect to local IP addresses. Note that all
+connection attempts to port 53 (DNS) will be refused, no matter the value of
+this setting. However, it may be still be unsafe to enable this setting, as the
+application may connect to a local DNS server listening on a non-standard port.
+The default value is `false'.
+
+.TP
 .I tordns_enable
 This enables the use of the 'tordns' feature in torsocks, which overrides the
 standard C library name resolution calls to use SOCKS.    The default value is 

--- a/src/common.h
+++ b/src/common.h
@@ -96,6 +96,8 @@ unsigned int resolve_ip(char *, int, int);
 #define MSGNOTICE 3
 #define MSGDEBUG  3
 
+#define DNS_PORT 53
+
 /* Required by some BSDs */
 #ifndef  MAP_ANONYMOUS
 #ifdef MAP_ANON

--- a/src/parser.c
+++ b/src/parser.c
@@ -51,6 +51,7 @@ static int handle_server(struct parsedfile *, int, char *);
 static int handle_type(struct parsedfile *config, int, char *);
 static int handle_port(struct parsedfile *config, int, char *);
 static int handle_local(struct parsedfile *, int, const char *);
+static int handle_local_connect_enable(struct parsedfile *, int, char *);
 static int handle_tordns_enabled(struct parsedfile *, int, char *);
 static int handle_tordns_deadpool_range(struct parsedfile *, int, const char *);
 static int handle_tordns_cache_size(struct parsedfile *, char *);
@@ -205,6 +206,8 @@ static int handle_line(struct parsedfile *config, char *line, int lineno) {
                 handle_defpass(config, lineno, words[2]);
             } else if (!strcmp(words[0], "local")) {
                 handle_local(config, lineno, words[2]);
+            } else if (!strcmp(words[0], "local_connect_enable")) {
+                handle_local_connect_enable(config, lineno, words[2]);
             } else if (!strcmp(words[0], "tordns_enable")) {
                 handle_tordns_enabled(config, lineno, words[2]);
             } else if (!strcmp(words[0], "tordns_deadpool_range")) {
@@ -488,6 +491,19 @@ static int handle_flag(char *value)
     } else {
         return -1;
     }
+}
+
+static int handle_local_connect_enable(struct parsedfile *config, int lineno,
+                           char *value)
+{
+    int val = handle_flag(value);
+    if(val == -1) {
+        show_msg(MSGERR, "Invalid value %s supplied for local_connect_enable at "
+                 "line %d in config file, IGNORED\n", value, lineno);
+    } else {
+        config->local_connect_enabled = val;
+    }
+    return 0;
 }
 
 static int handle_tordns_enabled(struct parsedfile *config, int lineno,

--- a/src/parser.h
+++ b/src/parser.h
@@ -54,6 +54,7 @@ struct parsedfile {
    struct netent *localnets;
    struct serverent defaultserver;
    struct serverent *paths;
+   int local_connect_enabled;
    int tordns_enabled;
    int tordns_failopen;
    unsigned int tordns_cache_size;

--- a/test/expectedresults.txt
+++ b/test/expectedresults.txt
@@ -13,7 +13,7 @@ libtorsocks: connect: Connection is a UDP or ICMP stream, may be a DNS request o
 libtorsocks: our_gethostbyaddr: resolved '38.229.70.16' to: 'vescum.torproject.org'
 libtorsocks: our_gethostbyname: 'www.torproject.org' requested
 libtorsocks: Got connection request
-libtorsocks: connect: Connection is to a local address (192.168.1.1), may be a TCP DNS request to a local DNS server so have to reject to be safe. Please report a bug to http://code.google.com/p/torsocks/issues/entry if this is preventing a program from working properly with torsocks.
+libtorsocks: connect: Connection is to a local address (192.168.1.1) on non-DNS port, may be a TCP DNS request to a local DNS server on a non-standard port, so have to reject to be safe. If you would like to allow this connection to happen, you may use the local_connect_enable option in the torsocks config file. Please report a bug to http://code.google.com/p/torsocks/issues/entry if this is preventing a program from working properly with torsocks.
 libtorsocks: Got connection request
 libtorsocks: Intercepted call to getpeername
 libtorsocks: Got res_init request
@@ -27,15 +27,15 @@ libtorsocks: Got connection request
 libtorsocks: Intercepted call to getpeername
 libtorsocks: Got res_init request
 libtorsocks: Got connection request
-libtorsocks: connect: Connection is to a local address (192.168.1.1), may be a TCP DNS request to a local DNS server so have to reject to be safe. Please report a bug to http://code.google.com/p/torsocks/issues/entry if this is preventing a program from working properly with torsocks.
+libtorsocks: connect: Connection is to a local address (192.168.1.1) on DNS port, may be a TCP DNS request to a local DNS server so have to reject to be safe. Please report a bug to http://code.google.com/p/torsocks/issues/entry if this is preventing a program from working properly with torsocks.
 libtorsocks: Got connection request
-libtorsocks: connect: Connection is to a local address (192.168.1.1), may be a TCP DNS request to a local DNS server so have to reject to be safe. Please report a bug to http://code.google.com/p/torsocks/issues/entry if this is preventing a program from working properly with torsocks.
+libtorsocks: connect: Connection is to a local address (192.168.1.1) on DNS port, may be a TCP DNS request to a local DNS server so have to reject to be safe. Please report a bug to http://code.google.com/p/torsocks/issues/entry if this is preventing a program from working properly with torsocks.
 libtorsocks: Got connection request
-libtorsocks: connect: Connection is to a local address (192.168.1.1), may be a TCP DNS request to a local DNS server so have to reject to be safe. Please report a bug to http://code.google.com/p/torsocks/issues/entry if this is preventing a program from working properly with torsocks.
+libtorsocks: connect: Connection is to a local address (192.168.1.1) on DNS port, may be a TCP DNS request to a local DNS server so have to reject to be safe. Please report a bug to http://code.google.com/p/torsocks/issues/entry if this is preventing a program from working properly with torsocks.
 libtorsocks: Got connection request
-libtorsocks: connect: Connection is to a local address (192.168.1.1), may be a TCP DNS request to a local DNS server so have to reject to be safe. Please report a bug to http://code.google.com/p/torsocks/issues/entry if this is preventing a program from working properly with torsocks.
+libtorsocks: connect: Connection is to a local address (192.168.1.1) on DNS port, may be a TCP DNS request to a local DNS server so have to reject to be safe. Please report a bug to http://code.google.com/p/torsocks/issues/entry if this is preventing a program from working properly with torsocks.
 libtorsocks: Got connection request
-libtorsocks: connect: Connection is to a local address (192.168.1.1), may be a TCP DNS request to a local DNS server so have to reject to be safe. Please report a bug to http://code.google.com/p/torsocks/issues/entry if this is preventing a program from working properly with torsocks.
+libtorsocks: connect: Connection is to a local address (192.168.1.1) on DNS port, may be a TCP DNS request to a local DNS server so have to reject to be safe. Please report a bug to http://code.google.com/p/torsocks/issues/entry if this is preventing a program from working properly with torsocks.
 socket: Operation not permitted
 
 ----------------------getaddrinfo() TEST-----------------

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -35,7 +35,7 @@ fi
 
 torsocks ./test_torsocks > /tmp/newresults.txt 2>&1
 output=`diff expectedresults.txt /tmp/newresults.txt`
-if ["$output" = ""]; then
+if [ "$output" = "" ]; then
   echo "Tests passed"
 else
   echo "Tests failed. Please post this output to http://code.google.com/p/torsocks/issues/entry"


### PR DESCRIPTION
Building upon [a patch from issue 28 on Google Code](https://code.google.com/p/torsocks/issues/detail?id=28#c7), this implements an option (`local_connect_enable`) in `torsocks.conf` which allows connections to local addresses.

The option is disabled by default (i.e. local connections are refused), and connections to port 53 are blocked unconditionally (regardless of the value of `local_connect_enable`).

This also includes an updated man page and test output.
